### PR TITLE
Refactor database insertion to use RxJava

### DIFF
--- a/app/src/main/java/com/glopez/phunapp/model/EventRepository.kt
+++ b/app/src/main/java/com/glopez/phunapp/model/EventRepository.kt
@@ -26,7 +26,7 @@ class EventRepository(
 
     private val eventDao: EventDao = eventDatabase.eventDao()
     private val apiResultState = MutableLiveData<ApiResponse<List<Event>>>()
-    private val disposables = CompositeDisposable()
+    private var disposables = CompositeDisposable()
 
     private var refreshTimestamp: Long = 0
     private val timeoutInMinutes = 1
@@ -106,6 +106,9 @@ class EventRepository(
 
     private fun insertEventsIntoDatabase(eventList: List<Event>) {
         lateinit var disposableInsertEvent: Disposable
+        if (disposables.isDisposed) {
+            disposables = CompositeDisposable()
+        }
         for (event: Event in eventList) {
             // If the id field was not present in the Response object, the default value of 0 will be set.
             // If this is the case, the Event will not be inserted into the database.
@@ -138,7 +141,9 @@ class EventRepository(
     }
 
     fun clearDisposables() {
-        disposables.clear()
+        if (!disposables.isDisposed) {
+            disposables.dispose()
+        }
     }
 }
 

--- a/app/src/main/java/com/glopez/phunapp/view/activities/MainActivity.kt
+++ b/app/src/main/java/com/glopez/phunapp/view/activities/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
             Timber.d(getString(R.string.main_no_network_no_database))
         } else {
             if (eventList == null)
-                Toast.makeText(this, "Null resource data", Toast.LENGTH_LONG).show()
+                Toast.makeText(this, "Received a null EventList", Toast.LENGTH_LONG).show()
             else
                 adapter.setEvents(eventList)
         }

--- a/app/src/main/java/com/glopez/phunapp/view/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/glopez/phunapp/view/viewmodels/EventViewModel.kt
@@ -20,10 +20,8 @@ class EventViewModel(private val eventRepo: EventRepository) : ViewModel() {
     init {
         eventsResourceStatus.addSource(dbSource) { data ->
             if (data.isNullOrEmpty()) {
-//                eventsResourceStatus.removeSource(dbSource)
                 eventsResourceStatus.value = Resource.Loading(emptyList())
             } else {
-//                eventsResourceStatus.removeSource(dbSource)
                 eventsResourceStatus.value = Resource.Success(data)
             }
         }
@@ -51,13 +49,11 @@ class EventViewModel(private val eventRepo: EventRepository) : ViewModel() {
                 is ApiResponse.Success<List<Event>>,
                 is ApiResponse.EmptyBody<List<Event>> -> {
                     eventsResourceStatus.addSource(updatedEventsFromDatabase) { data ->
-//                        eventsResourceStatus.removeSource(apiResponseStatus)
                         eventsResourceStatus.value = Resource.Success(data)
                     }
                 }
                 is ApiResponse.Error -> {
                     eventsResourceStatus.addSource(updatedEventsFromDatabase) { data ->
-//                        eventsResourceStatus.removeSource(apiResponseStatus)
                         if (data.isNullOrEmpty())
                             eventsResourceStatus.value = Resource.Error(Exception(it.errorMessage))
                         else


### PR DESCRIPTION
The purpose of this PR is to refactor the Repository operation of inserting Events into the Room Database.  The refactor will use RxJava in place of using an AsyncTask.  This branch was branched off of **feature/refactor-model-layer** which is another larger PR that will address many changes made to the model layer.

The diagram below illustrates the happy path of retrieving Events from the database, refreshing the database with new data from the network, and inserting these events into the database.

![RxJava Insert Flow](https://user-images.githubusercontent.com/13700908/62599899-5615e900-b8a2-11e9-8082-371b157bd43b.jpg)
